### PR TITLE
refactor: user-owned categories with seeding and migration

### DIFF
--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -182,6 +182,7 @@ class _VaultAwareShell extends ConsumerStatefulWidget {
 class _VaultAwareShellState extends ConsumerState<_VaultAwareShell>
     with WidgetsBindingObserver {
   bool _recurringGenerated = false;
+  bool _categoriesMigrationChecked = false;
 
   @override
   void initState() {
@@ -226,6 +227,27 @@ class _VaultAwareShellState extends ConsumerState<_VaultAwareShell>
     });
   }
 
+  /// Migre les catégories globales vers le scope perso (one-shot par utilisateur).
+  /// Idempotent : marqué via le setting `categories_migrated`.
+  Future<void> _migrateCategoriesIfNeeded() async {
+    try {
+      final settingsRepo = ref.read(settingsRepositoryProvider);
+      if (await settingsRepo.isCategoriesMigrated()) return;
+
+      final categoryRepo = ref.read(categoryRepositoryProvider);
+      final result = await categoryRepo.migrateGlobalCategories();
+      result.fold(
+        (err) => debugPrint('[Categories] Migration failed: ${err.message}'),
+        (_) async {
+          await settingsRepo.setCategoriesMigrated();
+          debugPrint('[Categories] Migration done');
+        },
+      );
+    } catch (e) {
+      debugPrint('[Categories] Migration error: $e');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final vaultState = ref.watch(vaultNotifierProvider);
@@ -247,6 +269,14 @@ class _VaultAwareShellState extends ConsumerState<_VaultAwareShell>
       _recurringGenerated = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _generateRecurringTransactions();
+      });
+    }
+
+    // Migration one-shot des catégories globales vers le scope perso
+    if (!_categoriesMigrationChecked) {
+      _categoriesMigrationChecked = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _migrateCategoriesIfNeeded();
       });
     }
 

--- a/mobile/lib/src/data/constants/default_categories.dart
+++ b/mobile/lib/src/data/constants/default_categories.dart
@@ -1,0 +1,38 @@
+import 'package:monasafe/src/data/models/enums.dart';
+
+/// Représentation d'une catégorie par défaut à injecter dans le compte
+/// d'un utilisateur lors de l'inscription ou de la migration.
+class DefaultCategorySeed {
+  const DefaultCategorySeed({
+    required this.name,
+    required this.iconKey,
+    required this.color,
+    required this.type,
+  });
+
+  final String name;
+  final String iconKey;
+  final int color;
+  final CategoryType type;
+}
+
+/// Set minimal de catégories injectées dans le compte de l'utilisateur
+/// à l'inscription. L'utilisateur en devient propriétaire et peut les
+/// renommer, modifier ou supprimer librement.
+///
+/// Source de vérité partagée avec `web/utils/defaultCategories.ts` :
+/// toute modification doit être répercutée des deux côtés pour rester
+/// cohérent.
+const List<DefaultCategorySeed> kDefaultCategories = [
+  // Dépenses
+  DefaultCategorySeed(name: 'Alimentation', iconKey: 'shopping-cart', color: 0xFFE87B4D, type: CategoryType.expense),
+  DefaultCategorySeed(name: 'Logement', iconKey: 'home', color: 0xFF1B5E5A, type: CategoryType.expense),
+  DefaultCategorySeed(name: 'Transport', iconKey: 'car', color: 0xFF2196F3, type: CategoryType.expense),
+  DefaultCategorySeed(name: 'Loisirs', iconKey: 'gamepad-2', color: 0xFF9C27B0, type: CategoryType.expense),
+  DefaultCategorySeed(name: 'Santé', iconKey: 'heart-pulse', color: 0xFFF44336, type: CategoryType.expense),
+  DefaultCategorySeed(name: 'Autres dépenses', iconKey: 'ellipsis', color: 0xFF607D8B, type: CategoryType.expense),
+
+  // Revenus
+  DefaultCategorySeed(name: 'Salaire', iconKey: 'wallet', color: 0xFF4CAF50, type: CategoryType.income),
+  DefaultCategorySeed(name: 'Autres revenus', iconKey: 'arrow-up-circle', color: 0xFF00BCD4, type: CategoryType.income),
+];

--- a/mobile/lib/src/data/models/user_setting.dart
+++ b/mobile/lib/src/data/models/user_setting.dart
@@ -49,4 +49,7 @@ abstract final class SettingsKeys {
 
   /// ID du compte principal (String)
   static const String primaryAccountId = 'primary_account_id';
+
+  /// Migration des catégories globales vers le scope perso effectuée (bool)
+  static const String categoriesMigrated = 'categories_migrated';
 }

--- a/mobile/lib/src/data/repositories/category_repository.dart
+++ b/mobile/lib/src/data/repositories/category_repository.dart
@@ -25,11 +25,6 @@ class CategoryDeletionError extends CategoryError {
   const CategoryDeletionError(super.message);
 }
 
-class CategoryIsDefaultError extends CategoryError {
-  const CategoryIsDefaultError()
-      : super('Les catégories par défaut ne peuvent pas être supprimées');
-}
-
 class CategoryFetchError extends CategoryError {
   const CategoryFetchError(super.message);
 }
@@ -127,17 +122,12 @@ class CategoryRepository {
     }
   }
 
-  /// Supprime une catégorie personnalisée
+  /// Supprime une catégorie de l'utilisateur
   Future<Either<CategoryError, Unit>> deleteCategory(String id) async {
     try {
       final existing = await _categoryService.getCategoryById(id);
       if (existing == null) {
         return const Left(CategoryNotFoundError());
-      }
-
-      // Vérifie si c'est une catégorie par défaut
-      if (existing.isDefault) {
-        return const Left(CategoryIsDefaultError());
       }
 
       await _categoryService.deleteCategory(id);
@@ -147,9 +137,23 @@ class CategoryRepository {
     }
   }
 
-  /// Vérifie si une catégorie est une catégorie par défaut
-  Future<bool> isDefaultCategory(String id) async {
-    final category = await _categoryService.getCategoryById(id);
-    return category?.isDefault ?? false;
+  /// Injecte le set de catégories par défaut (idempotent)
+  Future<Either<CategoryError, Unit>> seedDefaultCategories() async {
+    try {
+      await _categoryService.seedDefaultCategories();
+      return const Right(unit);
+    } catch (e) {
+      return Left(CategoryCreationError('Erreur seed catégories: $e'));
+    }
+  }
+
+  /// Migre les catégories globales vers le scope perso de l'utilisateur
+  Future<Either<CategoryError, Unit>> migrateGlobalCategories() async {
+    try {
+      await _categoryService.migrateGlobalCategories();
+      return const Right(unit);
+    } catch (e) {
+      return Left(CategoryUpdateError('Erreur migration catégories: $e'));
+    }
   }
 }

--- a/mobile/lib/src/data/repositories/settings_repository.dart
+++ b/mobile/lib/src/data/repositories/settings_repository.dart
@@ -78,6 +78,18 @@ class SettingsRepository {
     return _settingsService.setValue(SettingsKeys.primaryAccountId, accountId);
   }
 
+  // ==================== MIGRATION CATÉGORIES ====================
+
+  /// Indique si la migration des catégories globales a été effectuée
+  Future<bool> isCategoriesMigrated() {
+    return _settingsService.getBool(SettingsKeys.categoriesMigrated);
+  }
+
+  /// Marque la migration des catégories comme effectuée
+  Future<void> setCategoriesMigrated() {
+    return _settingsService.setBool(SettingsKeys.categoriesMigrated, value: true);
+  }
+
   // ==================== UTILS ====================
 
   /// Réinitialise tous les paramètres (pour debug)
@@ -86,5 +98,6 @@ class SettingsRepository {
     await _settingsService.deleteValue(SettingsKeys.currency);
     await _settingsService.deleteValue(SettingsKeys.isAnonymous);
     await _settingsService.deleteValue(SettingsKeys.primaryAccountId);
+    await _settingsService.deleteValue(SettingsKeys.categoriesMigrated);
   }
 }

--- a/mobile/lib/src/data/services/category_service.dart
+++ b/mobile/lib/src/data/services/category_service.dart
@@ -1,3 +1,4 @@
+import 'package:monasafe/src/data/constants/default_categories.dart';
 import 'package:monasafe/src/data/models/models.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -9,12 +10,12 @@ class CategoryService {
 
   String get _userId => _client.auth.currentUser!.id;
 
-  /// Récupère toutes les catégories (par défaut + personnalisées)
+  /// Récupère toutes les catégories de l'utilisateur
   Future<List<Category>> getAllCategories() async {
     final response = await _client
         .from('categories')
         .select()
-        .or('user_id.eq.$_userId,user_id.is.null')
+        .eq('user_id', _userId)
         .order('name');
 
     return (response as List)
@@ -29,7 +30,7 @@ class CategoryService {
         .stream(primaryKey: ['id'])
         .order('name')
         .map((data) => data
-            .where((json) => json['user_id'] == _userId || json['user_id'] == null)
+            .where((json) => json['user_id'] == _userId)
             .map(Category.fromJson)
             .toList());
   }
@@ -42,7 +43,7 @@ class CategoryService {
         .eq('type', CategoryType.expense.name)
         .order('name')
         .map((data) => data
-            .where((json) => json['user_id'] == _userId || json['user_id'] == null)
+            .where((json) => json['user_id'] == _userId)
             .map(Category.fromJson)
             .toList());
   }
@@ -55,7 +56,7 @@ class CategoryService {
         .eq('type', CategoryType.income.name)
         .order('name')
         .map((data) => data
-            .where((json) => json['user_id'] == _userId || json['user_id'] == null)
+            .where((json) => json['user_id'] == _userId)
             .map(Category.fromJson)
             .toList());
   }
@@ -130,23 +131,164 @@ class CategoryService {
     return Category.fromJson(response);
   }
 
-  /// Supprime une catégorie personnalisée
+  /// Supprime une catégorie de l'utilisateur
   Future<void> deleteCategory(String id) async {
     await _client
         .from('categories')
         .delete()
         .eq('id', id)
-        .eq('user_id', _userId)
-        .eq('is_default', false);
+        .eq('user_id', _userId);
   }
 
-  /// Supprime toutes les catégories personnalisées de l'utilisateur
-  Future<void> deleteAllCustomCategories() async {
+  /// Supprime toutes les catégories de l'utilisateur
+  Future<void> deleteAllCategories() async {
     await _client
         .from('categories')
         .delete()
+        .eq('user_id', _userId);
+  }
+
+  /// Injecte le set de catégories par défaut dans le compte de l'utilisateur.
+  /// Idempotent : ne fait rien si l'utilisateur a déjà au moins une catégorie.
+  Future<void> seedDefaultCategories() async {
+    final existing = await _client
+        .from('categories')
+        .select('id')
         .eq('user_id', _userId)
-        .eq('is_default', false);
+        .limit(1);
+
+    if ((existing as List).isNotEmpty) return;
+
+    final now = DateTime.now().toIso8601String();
+    final rows = kDefaultCategories
+        .map((c) => {
+              'user_id': _userId,
+              'name': c.name,
+              'icon_key': c.iconKey,
+              'color': c.color,
+              'type': c.type.name,
+              'budget_limit': null,
+              'is_default': true,
+              'created_at': now,
+              'updated_at': now,
+            })
+        .toList();
+
+    await _client.from('categories').insert(rows);
+  }
+
+  /// Migre les catégories globales (`user_id IS NULL`) vers le scope perso.
+  ///
+  /// Pour chaque catégorie globale référencée par les transactions /
+  /// récurrences / budgets de l'utilisateur, crée une copie perso et
+  /// re-pointe les références. Complète ensuite avec les catégories du
+  /// set par défaut qui ne sont pas déjà couvertes.
+  Future<void> migrateGlobalCategories() async {
+    // 1. Catégories globales référencées
+    final referencedIds = <String>{};
+    for (final table in [
+      'transactions',
+      'recurring_transactions',
+      'user_budgets',
+    ]) {
+      final rows = await _client
+          .from(table)
+          .select('category_id')
+          .eq('user_id', _userId);
+      for (final row in rows as List) {
+        final id = (row as Map<String, dynamic>)['category_id'];
+        if (id is String) referencedIds.add(id);
+      }
+    }
+
+    final referencedGlobals = <Map<String, dynamic>>[];
+    if (referencedIds.isNotEmpty) {
+      final raw = await _client
+          .from('categories')
+          .select()
+          .filter('user_id', 'is', null)
+          .inFilter('id', referencedIds.toList()) as List;
+      referencedGlobals.addAll(raw.cast<Map<String, dynamic>>());
+    }
+
+    // 2. Crée les copies perso et re-pointe les références
+    if (referencedGlobals.isNotEmpty) {
+      final now = DateTime.now().toIso8601String();
+      final rows = referencedGlobals
+          .map((g) => {
+                'user_id': _userId,
+                'name': g['name'],
+                'icon_key': g['icon_key'],
+                'color': g['color'],
+                'type': g['type'],
+                'budget_limit': g['budget_limit'],
+                'is_default': true,
+                'created_at': now,
+                'updated_at': now,
+              })
+          .toList();
+
+      final inserted = (await _client
+          .from('categories')
+          .insert(rows)
+          .select() as List)
+          .cast<Map<String, dynamic>>();
+
+      for (var i = 0; i < referencedGlobals.length; i++) {
+        final oldId = referencedGlobals[i]['id'] as String;
+        final newId = inserted[i]['id'] as String;
+
+        await Future.wait([
+          _client
+              .from('transactions')
+              .update({'category_id': newId})
+              .eq('user_id', _userId)
+              .eq('category_id', oldId),
+          _client
+              .from('recurring_transactions')
+              .update({'category_id': newId})
+              .eq('user_id', _userId)
+              .eq('category_id', oldId),
+          _client
+              .from('user_budgets')
+              .update({'category_id': newId})
+              .eq('user_id', _userId)
+              .eq('category_id', oldId),
+        ]);
+      }
+    }
+
+    // 3. Complète avec les défauts non couverts (par nom + type)
+    final existing = await _client
+        .from('categories')
+        .select('name, type')
+        .eq('user_id', _userId) as List;
+
+    final have = <String>{};
+    for (final row in existing) {
+      final m = row as Map<String, dynamic>;
+      have.add('${m['type']}::${(m['name'] as String).toLowerCase()}');
+    }
+
+    final now = DateTime.now().toIso8601String();
+    final toAdd = kDefaultCategories
+        .where((c) => !have.contains('${c.type.name}::${c.name.toLowerCase()}'))
+        .map((c) => {
+              'user_id': _userId,
+              'name': c.name,
+              'icon_key': c.iconKey,
+              'color': c.color,
+              'type': c.type.name,
+              'budget_limit': null,
+              'is_default': true,
+              'created_at': now,
+              'updated_at': now,
+            })
+        .toList();
+
+    if (toAdd.isNotEmpty) {
+      await _client.from('categories').insert(toAdd);
+    }
   }
 
   /// Retourne la catégorie "Virement" du type donné, en la créant si nécessaire.

--- a/mobile/lib/src/data/services/data_management_service.dart
+++ b/mobile/lib/src/data/services/data_management_service.dart
@@ -51,7 +51,10 @@ class DataManagementService {
     // 4. Comptes
     await accountService.deleteAllAccounts();
 
-    // 5. Catégories personnalisées
-    await categoryService.deleteAllCustomCategories();
+    // 5. Catégories
+    await categoryService.deleteAllCategories();
+
+    // 6. Ré-injecte le set par défaut pour donner un point de départ
+    await categoryService.seedDefaultCategories();
   }
 }

--- a/mobile/lib/src/features/aggregators/settings/presentation/screens/categories_screen.dart
+++ b/mobile/lib/src/features/aggregators/settings/presentation/screens/categories_screen.dart
@@ -128,28 +128,25 @@ class _CategoriesScreenState extends ConsumerState<CategoriesScreen> {
                         color: cardColor,
                         borderRadius: BorderRadius.circular(12),
                       ),
-                      child: category.isDefault
-                          ? CategoryListTile(category: category)
-                          : FutureBuilder<int>(
-                              future: _getTransactionCount(category.id),
-                              builder: (context, snapshot) {
-                                final hasTransactions =
-                                    (snapshot.data ?? 0) > 0;
-                                return CategoryListTile(
-                                  category: category,
-                                  hasTransactions: hasTransactions,
-                                  onEdit: () async {
-                                    await CategoryFormModal.show(
-                                      context,
-                                      category: category,
-                                      categoryType: _selectedType,
-                                    );
-                                  },
-                                  onDelete: () =>
-                                      _showDeleteConfirmation(category),
-                                );
-                              },
-                            ),
+                      child: FutureBuilder<int>(
+                        future: _getTransactionCount(category.id),
+                        builder: (context, snapshot) {
+                          final hasTransactions = (snapshot.data ?? 0) > 0;
+                          return CategoryListTile(
+                            category: category,
+                            hasTransactions: hasTransactions,
+                            onEdit: () async {
+                              await CategoryFormModal.show(
+                                context,
+                                category: category,
+                                categoryType: _selectedType,
+                              );
+                            },
+                            onDelete: () =>
+                                _showDeleteConfirmation(category),
+                          );
+                        },
+                      ),
                     );
                   },
                 );

--- a/mobile/lib/src/features/aggregators/settings/presentation/widgets/category_list_tile.dart
+++ b/mobile/lib/src/features/aggregators/settings/presentation/widgets/category_list_tile.dart
@@ -59,53 +59,34 @@ class CategoryListTile extends StatelessWidget {
               ),
               const SizedBox(width: 14),
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      category.name,
-                      style: AppTextStyles.bodyLarge(color: textColor),
-                    ),
-                    if (category.isDefault) ...[
-                      const SizedBox(height: 2),
-                      Text(
-                        'Catégorie par défaut',
-                        style: AppTextStyles.caption(color: subtitleColor),
-                      ),
-                    ],
-                  ],
+                child: Text(
+                  category.name,
+                  style: AppTextStyles.bodyLarge(color: textColor),
                 ),
               ),
-              if (!category.isDefault) ...[
-                if (onEdit != null)
-                  IconButton(
-                    icon: Icon(
-                      Icons.edit_outlined,
-                      color: subtitleColor,
-                      size: 20,
-                    ),
-                    onPressed: onEdit,
-                    tooltip: 'Modifier',
+              if (onEdit != null)
+                IconButton(
+                  icon: Icon(
+                    Icons.edit_outlined,
+                    color: subtitleColor,
+                    size: 20,
                   ),
-                if (onDelete != null)
-                  IconButton(
-                    icon: Icon(
-                      Icons.delete_outline,
-                      color: hasTransactions
-                          ? subtitleColor.withValues(alpha: 0.4)
-                          : AppColors.error,
-                      size: 20,
-                    ),
-                    onPressed: hasTransactions
-                        ? () => _showCannotDeleteMessage(context)
-                        : onDelete,
-                    tooltip: 'Supprimer',
+                  onPressed: onEdit,
+                  tooltip: 'Modifier',
+                ),
+              if (onDelete != null)
+                IconButton(
+                  icon: Icon(
+                    Icons.delete_outline,
+                    color: hasTransactions
+                        ? subtitleColor.withValues(alpha: 0.4)
+                        : AppColors.error,
+                    size: 20,
                   ),
-              ] else
-                Icon(
-                  Icons.lock_outline,
-                  color: subtitleColor,
-                  size: 20,
+                  onPressed: hasTransactions
+                      ? () => _showCannotDeleteMessage(context)
+                      : onDelete,
+                  tooltip: 'Supprimer',
                 ),
             ],
           ),

--- a/mobile/lib/src/features/domain/onboarding/presentation/onboarding_controller.dart
+++ b/mobile/lib/src/features/domain/onboarding/presentation/onboarding_controller.dart
@@ -255,6 +255,13 @@ class OnboardingController extends _$OnboardingController {
         await settingsRepo.setPrimaryAccountId(primaryAccountId!);
       }
 
+      // Injecte les catégories par défaut dans le scope de l'utilisateur
+      final categoryRepo = ref.read(categoryRepositoryProvider);
+      await categoryRepo.seedDefaultCategories();
+
+      // Pas de migration à faire pour un nouvel utilisateur
+      await settingsRepo.setCategoriesMigrated();
+
       // Marque l'onboarding comme complété
       await settingsRepo.setOnboardingCompleted();
 

--- a/mobile/macos/Flutter/Flutter-Debug.xcconfig
+++ b/mobile/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/mobile/macos/Flutter/Flutter-Release.xcconfig
+++ b/mobile/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/mobile/macos/Podfile
+++ b/mobile/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -724,18 +724,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct main"
     description:
@@ -1153,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:

--- a/supabase/migrations/20260422_drop_global_categories_cleanup.sql
+++ b/supabase/migrations/20260422_drop_global_categories_cleanup.sql
@@ -1,0 +1,96 @@
+-- =============================================================================
+-- Cleanup post-migration : suppression des catégories globales et resserrement RLS
+-- =============================================================================
+-- À EXÉCUTER UNIQUEMENT après que :
+--   - 20260422_migrate_categories_to_users.sql ait tourné avec succès,
+--   - les 3 checks de fin de ce fichier renvoient bien 0,
+--   - les apps web et mobile aient été déployées avec le code qui ne lit
+--     plus les défauts globaux (PR « refonte catégories »).
+--
+-- Le script est défensif : il refuse de supprimer les globaux tant que des
+-- transactions/récurrences/budgets y font encore référence.
+-- =============================================================================
+
+BEGIN;
+
+-- Garde-fou : on ne touche à rien si des FKs pointent encore vers un global
+DO $$
+DECLARE
+  v_orphan_tx        int;
+  v_orphan_recurring int;
+  v_orphan_budgets   int;
+  v_unmigrated_users int;
+BEGIN
+  SELECT count(*) INTO v_orphan_tx
+  FROM public.transactions t
+  JOIN public.categories c ON c.id = t.category_id
+  WHERE c.user_id IS NULL;
+
+  SELECT count(*) INTO v_orphan_recurring
+  FROM public.recurring_transactions r
+  JOIN public.categories c ON c.id = r.category_id
+  WHERE c.user_id IS NULL;
+
+  SELECT count(*) INTO v_orphan_budgets
+  FROM public.user_budgets b
+  JOIN public.categories c ON c.id = b.category_id
+  WHERE c.user_id IS NULL;
+
+  SELECT count(*) INTO v_unmigrated_users
+  FROM auth.users u
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.user_settings s
+    WHERE s.user_id = u.id AND s.key = 'categories_migrated' AND s.value = 'true'
+  );
+
+  IF v_orphan_tx + v_orphan_recurring + v_orphan_budgets > 0 THEN
+    RAISE EXCEPTION
+      'Cleanup refusé : % transactions, % récurrences et % budgets pointent encore vers des catégories globales. Relancer la migration.',
+      v_orphan_tx, v_orphan_recurring, v_orphan_budgets;
+  END IF;
+
+  IF v_unmigrated_users > 0 THEN
+    RAISE EXCEPTION
+      'Cleanup refusé : % utilisateurs n''ont pas encore le flag categories_migrated.',
+      v_unmigrated_users;
+  END IF;
+
+  RAISE NOTICE 'Garde-fous OK, suppression des catégories globales en cours…';
+END;
+$$;
+
+-- 1. Suppression effective des catégories globales
+DELETE FROM public.categories WHERE user_id IS NULL;
+
+-- 2. Resserrement de la RLS sur la table categories
+--    Adapter le nom des policies à celles réellement présentes en base.
+--    Les commandes ci-dessous sont des EXEMPLES — vérifier d'abord avec :
+--      SELECT polname, polcmd FROM pg_policy
+--      WHERE polrelid = 'public.categories'::regclass;
+--
+-- DROP POLICY IF EXISTS "Categories are viewable by owner or anyone (defaults)"
+--   ON public.categories;
+--
+-- CREATE POLICY "Categories are viewable by owner"
+--   ON public.categories FOR SELECT
+--   USING (auth.uid() = user_id);
+--
+-- CREATE POLICY "Categories are insertable by owner"
+--   ON public.categories FOR INSERT
+--   WITH CHECK (auth.uid() = user_id);
+--
+-- CREATE POLICY "Categories are updatable by owner"
+--   ON public.categories FOR UPDATE
+--   USING (auth.uid() = user_id)
+--   WITH CHECK (auth.uid() = user_id);
+--
+-- CREATE POLICY "Categories are deletable by owner"
+--   ON public.categories FOR DELETE
+--   USING (auth.uid() = user_id);
+
+-- 3. Optionnel : rendre user_id NOT NULL maintenant que plus aucune ligne
+--    n'a user_id IS NULL. Renforce l'invariant côté schéma.
+--
+-- ALTER TABLE public.categories ALTER COLUMN user_id SET NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/20260422_migrate_categories_to_users.sql
+++ b/supabase/migrations/20260422_migrate_categories_to_users.sql
@@ -1,0 +1,164 @@
+-- =============================================================================
+-- Migration : appropriation des catégories par utilisateur
+-- =============================================================================
+-- Pour chaque utilisateur qui n'a pas encore été migré :
+--   1. Copie dans son scope perso les catégories globales (user_id IS NULL)
+--      qu'il référence via ses transactions / récurrences / budgets.
+--   2. Re-pointe ses transactions / récurrences / budgets vers les copies.
+--   3. Complète avec les catégories du nouveau set par défaut qui ne sont pas
+--      déjà présentes (match insensible à la casse sur (type, name)).
+--   4. Marque `categories_migrated = true` dans user_settings.
+--
+-- Idempotent : un utilisateur déjà flaggé est skippé.
+-- Atomique : tout se déroule dans une transaction unique.
+-- À exécuter dans le SQL Editor Supabase, AVANT le script de cleanup.
+--
+-- Source de vérité du set par défaut alignée avec :
+--   - web/utils/defaultCategories.ts
+--   - mobile/lib/src/data/constants/default_categories.dart
+-- =============================================================================
+
+BEGIN;
+
+-- Set par défaut curaté (8 catégories). Couleurs ARGB en décimal :
+--   0xFFE87B4D = 4286922061    0xFF1B5E5A = 4279885402
+--   0xFF2196F3 = 4280892147    0xFF9C27B0 = 4287384496
+--   0xFFF44336 = 4292030262    0xFF607D8B = 4284506507
+--   0xFF4CAF50 = 4283215696    0xFF00BCD4 = 4278238420
+CREATE TEMP TABLE _default_categories (
+  name      text   NOT NULL,
+  icon_key  text   NOT NULL,
+  color     bigint NOT NULL,
+  type      text   NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _default_categories (name, icon_key, color, type) VALUES
+  ('Alimentation',     'shopping-cart',   4286922061, 'expense'),
+  ('Logement',         'home',            4279885402, 'expense'),
+  ('Transport',        'car',             4280892147, 'expense'),
+  ('Loisirs',          'gamepad-2',       4287384496, 'expense'),
+  ('Santé',            'heart-pulse',     4292030262, 'expense'),
+  ('Autres dépenses',  'ellipsis',        4284506507, 'expense'),
+  ('Salaire',          'wallet',          4283215696, 'income'),
+  ('Autres revenus',   'arrow-up-circle', 4278238420, 'income');
+
+DO $$
+DECLARE
+  v_user_id  uuid;
+  v_global   record;
+  v_new_id   uuid;
+  v_now      timestamptz := now();
+  v_migrated int := 0;
+  v_skipped  int := 0;
+BEGIN
+  -- Itère sur tous les utilisateurs non encore migrés
+  FOR v_user_id IN
+    SELECT u.id
+    FROM auth.users u
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.user_settings s
+      WHERE s.user_id = u.id
+        AND s.key = 'categories_migrated'
+        AND s.value = 'true'
+    )
+  LOOP
+    -- 1+2. Pour chaque catégorie globale référencée par cet utilisateur,
+    --      crée une copie perso et re-pointe ses FKs vers la copie.
+    FOR v_global IN
+      SELECT c.*
+      FROM public.categories c
+      WHERE c.user_id IS NULL
+        AND c.id IN (
+          SELECT category_id FROM public.transactions
+            WHERE user_id = v_user_id AND category_id IS NOT NULL
+          UNION
+          SELECT category_id FROM public.recurring_transactions
+            WHERE user_id = v_user_id AND category_id IS NOT NULL
+          UNION
+          SELECT category_id FROM public.user_budgets
+            WHERE user_id = v_user_id AND category_id IS NOT NULL
+        )
+    LOOP
+      INSERT INTO public.categories (
+        user_id, name, icon_key, color, type, budget_limit,
+        is_default, created_at, updated_at
+      )
+      VALUES (
+        v_user_id, v_global.name, v_global.icon_key, v_global.color,
+        v_global.type, v_global.budget_limit,
+        true, v_now, v_now
+      )
+      RETURNING id INTO v_new_id;
+
+      UPDATE public.transactions
+        SET category_id = v_new_id
+        WHERE user_id = v_user_id AND category_id = v_global.id;
+
+      UPDATE public.recurring_transactions
+        SET category_id = v_new_id
+        WHERE user_id = v_user_id AND category_id = v_global.id;
+
+      UPDATE public.user_budgets
+        SET category_id = v_new_id
+        WHERE user_id = v_user_id AND category_id = v_global.id;
+    END LOOP;
+
+    -- 3. Complète avec les défauts du set curaté qui manquent
+    --    (match insensible à la casse sur le couple (type, name))
+    INSERT INTO public.categories (
+      user_id, name, icon_key, color, type, budget_limit,
+      is_default, created_at, updated_at
+    )
+    SELECT
+      v_user_id, d.name, d.icon_key, d.color, d.type, NULL,
+      true, v_now, v_now
+    FROM _default_categories d
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.categories c
+      WHERE c.user_id = v_user_id
+        AND c.type = d.type
+        AND lower(c.name) = lower(d.name)
+    );
+
+    -- 4. Marque l'utilisateur comme migré
+    INSERT INTO public.user_settings (user_id, key, value, updated_at)
+    VALUES (v_user_id, 'categories_migrated', 'true', v_now)
+    ON CONFLICT (user_id, key) DO UPDATE
+      SET value = excluded.value,
+          updated_at = excluded.updated_at;
+
+    v_migrated := v_migrated + 1;
+  END LOOP;
+
+  SELECT count(*) INTO v_skipped
+  FROM public.user_settings
+  WHERE key = 'categories_migrated' AND value = 'true';
+  v_skipped := v_skipped - v_migrated;
+
+  RAISE NOTICE 'Migration catégories : % migré(s), % déjà à jour', v_migrated, v_skipped;
+END;
+$$;
+
+COMMIT;
+
+-- =============================================================================
+-- Vérifications post-migration (à exécuter avant le cleanup)
+-- =============================================================================
+-- a) Tous les utilisateurs ont bien le flag → doit retourner 0
+--    SELECT count(*) FROM auth.users u
+--    WHERE NOT EXISTS (
+--      SELECT 1 FROM public.user_settings s
+--      WHERE s.user_id = u.id AND s.key = 'categories_migrated' AND s.value = 'true'
+--    );
+--
+-- b) Aucune FK ne pointe vers une catégorie globale → doit retourner 0 pour chaque
+--    SELECT count(*) FROM public.transactions t
+--      JOIN public.categories c ON c.id = t.category_id WHERE c.user_id IS NULL;
+--    SELECT count(*) FROM public.recurring_transactions r
+--      JOIN public.categories c ON c.id = r.category_id WHERE c.user_id IS NULL;
+--    SELECT count(*) FROM public.user_budgets b
+--      JOIN public.categories c ON c.id = b.category_id WHERE c.user_id IS NULL;
+--
+-- c) Combien de catégories globales restent (informatif) :
+--    SELECT count(*) FROM public.categories WHERE user_id IS NULL;

--- a/web/components/settings/CategoryListTile.vue
+++ b/web/components/settings/CategoryListTile.vue
@@ -28,13 +28,10 @@ const emit = defineEmits<{
       <p class="text-sm font-medium text-gray-900 dark:text-white truncate">
         {{ props.category.name }}
       </p>
-      <p v-if="props.category.isDefault" class="text-xs text-gray-500 dark:text-gray-400">
-        Par défaut
-      </p>
     </div>
 
-    <!-- Actions (uniquement si non default) -->
-    <div v-if="!props.category.isDefault" class="flex items-center gap-1">
+    <!-- Actions -->
+    <div class="flex items-center gap-1">
       <button
         type="button"
         class="p-2 rounded-lg text-gray-400 hover:text-primary hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"

--- a/web/composables/useCategories.ts
+++ b/web/composables/useCategories.ts
@@ -1,6 +1,7 @@
 import type { Category } from '~/types/models'
 import type { CategoryType } from '~/types/enums'
 import type { RealtimeChannel } from '@supabase/supabase-js'
+import { DEFAULT_CATEGORIES } from '~/utils/defaultCategories'
 
 interface CreateCategoryData {
   name: string
@@ -62,7 +63,7 @@ export function useCategories() {
       const { data, error } = await supabase
         .from('categories')
         .select('*')
-        .or(`user_id.eq.${user.value.id},user_id.is.null`)
+        .eq('user_id', user.value.id)
         .order('name')
 
       if (error) throw error
@@ -160,13 +161,6 @@ export function useCategories() {
     store.setError(null)
 
     try {
-      // Vérifier si c'est une catégorie par défaut
-      const category = store.categoryById(id)
-      if (category?.isDefault) {
-        store.setError('Les catégories par défaut ne peuvent pas être supprimées.')
-        return false
-      }
-
       // Vérifier s'il y a des transactions liées
       const { count, error: countError } = await supabase
         .from('transactions')
@@ -195,6 +189,49 @@ export function useCategories() {
       return false
     } finally {
       store.setLoading(false)
+    }
+  }
+
+  /**
+   * Injecte le set de catégories par défaut dans le compte de l'utilisateur.
+   * Idempotent : ne fait rien si l'utilisateur a déjà au moins une catégorie.
+   */
+  async function seedDefaultCategories(): Promise<void> {
+    if (!user.value) return
+
+    const { count, error: countError } = await supabase
+      .from('categories')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.value.id)
+
+    if (countError) {
+      store.setError(countError.message)
+      return
+    }
+    if (count && count > 0) return
+
+    const rows = DEFAULT_CATEGORIES.map(c => ({
+      user_id: user.value!.id,
+      name: c.name,
+      icon_key: c.iconKey,
+      color: c.color,
+      type: c.type,
+      budget_limit: null,
+      is_default: true,
+    }))
+
+    const { data, error } = await supabase
+      .from('categories')
+      .insert(rows)
+      .select()
+
+    if (error) {
+      store.setError(error.message)
+      return
+    }
+
+    for (const row of data ?? []) {
+      store.addCategory(mapCategory(row))
     }
   }
 
@@ -252,6 +289,7 @@ export function useCategories() {
     createCategory,
     updateCategory,
     deleteCategory,
+    seedDefaultCategories,
     subscribeRealtime,
     unsubscribeRealtime,
     setError: store.setError,

--- a/web/composables/useDataManagement.ts
+++ b/web/composables/useDataManagement.ts
@@ -15,6 +15,7 @@ export function useDataManagement() {
   const recurringStore = useRecurringStore()
   const accountsStore = useAccountsStore()
   const categoriesStore = useCategoriesStore()
+  const { seedDefaultCategories } = useCategories()
 
   /**
    * Supprime toutes les transactions de l'utilisateur
@@ -142,7 +143,7 @@ export function useDataManagement() {
         .eq('user_id', user.value.id)
       if (e4) throw e4
 
-      // 5. Catégories personnalisées (pas les default)
+      // 5. Catégories
       const { error: e5 } = await supabase
         .from('categories')
         .delete()
@@ -153,9 +154,10 @@ export function useDataManagement() {
       transactionsStore.reset()
       recurringStore.setRecurrings([])
       accountsStore.setAccounts([])
-      categoriesStore.setCategories(
-        categoriesStore.categories.filter(c => c.isDefault),
-      )
+      categoriesStore.setCategories([])
+
+      // Ré-injecte le set par défaut pour que l'utilisateur ait un point de départ
+      await seedDefaultCategories()
 
       return true
     } catch (e: unknown) {

--- a/web/middleware/categoriesMigration.global.ts
+++ b/web/middleware/categoriesMigration.global.ts
@@ -1,0 +1,139 @@
+import { DEFAULT_CATEGORIES } from '~/utils/defaultCategories'
+
+/**
+ * Migration des catégories globales (user_id IS NULL) vers le scope perso
+ * de l'utilisateur. Exécutée une fois par utilisateur, idempotente via
+ * un flag `categories_migrated` dans `user_settings`.
+ *
+ * Pour chaque catégorie globale référencée par les transactions /
+ * récurrences / budgets de l'utilisateur, on crée une copie perso
+ * et on re-pointe les références vers cette copie. Les défauts non
+ * référencés sont remplacés par le set curaté DEFAULT_CATEGORIES.
+ */
+export default defineNuxtRouteMiddleware(async (to) => {
+  const user = useSupabaseUser()
+  if (!user.value) return
+
+  const isExcluded =
+    to.path === '/' ||
+    to.path.startsWith('/auth') ||
+    to.path === '/terms' ||
+    to.path === '/privacy' ||
+    to.path.startsWith('/onboarding')
+
+  if (isExcluded) return
+
+  const migrationStatus = useState<Record<string, boolean>>('categories-migration-status', () => ({}))
+  const uid = user.value.id
+
+  if (migrationStatus.value[uid]) return
+
+  const supabase = useSupabaseClient<any>()
+
+  try {
+    const { data: flagRow } = await supabase
+      .from('user_settings')
+      .select('value')
+      .eq('user_id', uid)
+      .eq('key', 'categories_migrated')
+      .maybeSingle() as { data: { value: string } | null }
+
+    if (flagRow?.value === 'true') {
+      migrationStatus.value[uid] = true
+      return
+    }
+
+    // Catégories globales référencées par l'utilisateur
+    const referencedIds = new Set<string>()
+
+    for (const table of ['transactions', 'recurring_transactions', 'user_budgets']) {
+      const { data } = await supabase
+        .from(table)
+        .select('category_id')
+        .eq('user_id', uid)
+      for (const row of (data ?? []) as { category_id: string }[]) {
+        if (row.category_id) referencedIds.add(row.category_id)
+      }
+    }
+
+    let referencedGlobals: any[] = []
+    if (referencedIds.size > 0) {
+      const { data } = await supabase
+        .from('categories')
+        .select('*')
+        .is('user_id', null)
+        .in('id', Array.from(referencedIds))
+      referencedGlobals = data ?? []
+    }
+
+    // Crée les copies perso des catégories référencées
+    const oldToNew = new Map<string, string>()
+    if (referencedGlobals.length > 0) {
+      const rows = referencedGlobals.map(g => ({
+        user_id: uid,
+        name: g.name,
+        icon_key: g.icon_key,
+        color: g.color,
+        type: g.type,
+        budget_limit: g.budget_limit,
+        is_default: true,
+      }))
+      const { data: inserted, error: insErr } = await supabase
+        .from('categories')
+        .insert(rows)
+        .select()
+      if (insErr) throw insErr
+
+      for (let i = 0; i < referencedGlobals.length; i++) {
+        oldToNew.set(referencedGlobals[i].id, (inserted ?? [])[i].id)
+      }
+
+      // Re-pointe transactions / récurrences / budgets vers les copies
+      for (const [oldId, newId] of oldToNew) {
+        await Promise.all([
+          supabase.from('transactions').update({ category_id: newId }).eq('user_id', uid).eq('category_id', oldId),
+          supabase.from('recurring_transactions').update({ category_id: newId }).eq('user_id', uid).eq('category_id', oldId),
+          supabase.from('user_budgets').update({ category_id: newId }).eq('user_id', uid).eq('category_id', oldId),
+        ])
+      }
+    }
+
+    // Complète avec les catégories du nouveau set par défaut qui ne sont pas
+    // déjà couvertes (par nom + type) — pour donner un point de départ.
+    const { data: existingPerso } = await supabase
+      .from('categories')
+      .select('name, type')
+      .eq('user_id', uid)
+
+    const have = new Set(
+      ((existingPerso ?? []) as { name: string; type: string }[]).map(c => `${c.type}::${c.name.toLowerCase()}`),
+    )
+    const toAdd = DEFAULT_CATEGORIES
+      .filter(c => !have.has(`${c.type}::${c.name.toLowerCase()}`))
+      .map(c => ({
+        user_id: uid,
+        name: c.name,
+        icon_key: c.iconKey,
+        color: c.color,
+        type: c.type,
+        budget_limit: null,
+        is_default: true,
+      }))
+
+    if (toAdd.length > 0) {
+      await supabase.from('categories').insert(toAdd)
+    }
+
+    await supabase
+      .from('user_settings')
+      .upsert(
+        { user_id: uid, key: 'categories_migrated', value: 'true' },
+        { onConflict: 'user_id,key' },
+      )
+
+    migrationStatus.value[uid] = true
+  } catch (e: unknown) {
+    console.error('Erreur migration catégories:', e instanceof Error ? e.message : e)
+    // On ne bloque pas la navigation : la migration sera retentée au prochain login
+  }
+})

--- a/web/pages/onboarding/index.vue
+++ b/web/pages/onboarding/index.vue
@@ -8,6 +8,7 @@ definePageMeta({
 const router = useRouter()
 const { updateSetting, completeOnboarding } = useSettings()
 const { createAccount } = useAccounts()
+const { seedDefaultCategories } = useCategories()
 
 // Navigation
 const questionIndex = ref(0)
@@ -71,6 +72,7 @@ async function finish() {
 
   try {
     await updateSetting('currency', currency.value)
+    await seedDefaultCategories()
 
     if (wantsChecking.value) {
       await createAccount({

--- a/web/utils/defaultCategories.ts
+++ b/web/utils/defaultCategories.ts
@@ -1,0 +1,27 @@
+import { CategoryType } from '~/types/enums'
+
+export interface DefaultCategorySeed {
+  name: string
+  iconKey: string
+  color: number
+  type: CategoryType
+}
+
+/**
+ * Set minimal de catégories injectées dans le compte de l'utilisateur
+ * à l'inscription. L'utilisateur en devient propriétaire et peut les
+ * renommer, modifier ou supprimer librement.
+ */
+export const DEFAULT_CATEGORIES: DefaultCategorySeed[] = [
+  // Dépenses
+  { name: 'Alimentation', iconKey: 'shopping-cart', color: 0xFFE87B4D, type: CategoryType.EXPENSE },
+  { name: 'Logement', iconKey: 'home', color: 0xFF1B5E5A, type: CategoryType.EXPENSE },
+  { name: 'Transport', iconKey: 'car', color: 0xFF2196F3, type: CategoryType.EXPENSE },
+  { name: 'Loisirs', iconKey: 'gamepad-2', color: 0xFF9C27B0, type: CategoryType.EXPENSE },
+  { name: 'Santé', iconKey: 'heart-pulse', color: 0xFFF44336, type: CategoryType.EXPENSE },
+  { name: 'Autres dépenses', iconKey: 'ellipsis', color: 0xFF607D8B, type: CategoryType.EXPENSE },
+
+  // Revenus
+  { name: 'Salaire', iconKey: 'wallet', color: 0xFF4CAF50, type: CategoryType.INCOME },
+  { name: 'Autres revenus', iconKey: 'arrow-up-circle', color: 0xFF00BCD4, type: CategoryType.INCOME },
+]


### PR DESCRIPTION
## Contexte

  Les catégories par défaut étaient stockées globalement dans Supabase (`user_id IS NULL`, `is_default = true`) et partagées par tous les utilisateurs. Conséquences :

  - Trop nombreuses, aucune curation possible côté utilisateur.
  - Verrouillées : impossible de renommer, modifier ou supprimer → bruit visuel permanent dans le sélecteur de transactions et dans `/settings/categories`.

  Cette PR fait que **chaque utilisateur possède ses propres catégories**. Plus aucune catégorie globale verrouillée.

  ## Changements

  ### Set par défaut curaté
  - 8 catégories essentielles (6 dépenses, 2 revenus) définies une fois et partagées web ↔ mobile :
    - `web/utils/defaultCategories.ts`
    - `mobile/lib/src/data/constants/default_categories.dart`

  ### Seeding à l'inscription
  - À l'onboarding, le set est inséré dans le scope de l'utilisateur (`user_id = current`, `is_default = true`).
  - Web : `useCategories.seedDefaultCategories()` appelé depuis `pages/onboarding/index.vue`.
  - Mobile : `CategoryRepository.seedDefaultCategories()` appelé depuis `OnboardingController.completeOnboarding()`.
  - Idempotent : ne fait rien si l'utilisateur a déjà des catégories.

  ### Migration des utilisateurs existants
  Trois mécanismes complémentaires, tous gated par un flag `categories_migrated` dans `user_settings` :

  1. **SQL one-shot côté serveur** — `supabase/migrations/20260422_migrate_categories_to_users.sql` : copie les globaux référencés dans le scope perso, re-pointe `transactions` / `recurring_transactions` /
  `user_budgets`, complète avec le set curaté, pose le flag. Idempotent, atomique. À exécuter manuellement dans le SQL Editor.
  2. **Filet web** — `web/middleware/categoriesMigration.global.ts` : même logique au prochain accès, no-op si le flag est déjà posé.
  3. **Filet mobile** — `_VaultAwareShell` (`mobile/lib/main.dart`) : déclenche `CategoryRepository.migrateGlobalCategories()` une fois après le déverrouillage du vault.

  ### Levée des verrous
  - `useCategories.deleteCategory` (web) et `CategoryRepository.deleteCategory` (mobile) : suppression du check `isDefault`. La protection « catégorie utilisée par des transactions » est conservée.
  - `CategoryListTile` (web + mobile) : retrait du badge « Par défaut » et de l'icône cadenas. Boutons edit/delete toujours visibles.
  - `categories_screen.dart` (mobile) : suppression du ternaire `category.isDefault`.

  ### Reset des données
  - `useDataManagement.deleteAllData` (web) et `DataManagementService.deleteAllUserData` (mobile) : wipe complet des catégories puis ré-injection du set par défaut.

  ### Cleanup base de données (à exécuter dans un second temps)
  - `supabase/migrations/20260422_drop_global_categories_cleanup.sql` : `DELETE FROM categories WHERE user_id IS NULL` + templates RLS resserrée (`user_id = auth.uid()`) + option `ALTER COLUMN user_id SET NOT
  NULL`. Garde-fous au début : `RAISE EXCEPTION` si une seule FK pointe encore vers un global ou si un user n'a pas le flag.

  ## Procédure de déploiement

  1. Merger cette PR en staging et valider le comportement.
  2. Exécuter `20260422_migrate_categories_to_users.sql` dans le SQL Editor de l'environnement cible.
  3. Lancer les 3 requêtes de check commentées en bas du script (toutes doivent renvoyer 0).
  4. Déployer le code (web + mobile).
  5. Après quelques jours en zone tampon : exécuter `20260422_drop_global_categories_cleanup.sql` puis adapter les blocs RLS commentés aux noms réels des policies.